### PR TITLE
Install Vac to the Python 2.7 library path as well

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ vac.tgz: $(TGZ_FILES)
 install: $(INSTALL_FILES)
 	mkdir -p $(RPM_BUILD_ROOT)/usr/sbin \
 		 $(RPM_BUILD_ROOT)/usr/lib64/python2.6/site-packages/vac \
+		 $(RPM_BUILD_ROOT)/usr/lib64/python2.7/site-packages/vac \
 	         $(RPM_BUILD_ROOT)/usr/share/doc/vac-$(VERSION) \
 		 $(RPM_BUILD_ROOT)/usr/share/man/man1 \
 		 $(RPM_BUILD_ROOT)/usr/share/man/man5 \
@@ -72,6 +73,8 @@ install: $(INSTALL_FILES)
 	   $(RPM_BUILD_ROOT)/usr/sbin
 	cp __init__.py shared.py vacutils.py \
 	   $(RPM_BUILD_ROOT)/usr/lib64/python2.6/site-packages/vac
+	cp __init__.py shared.py vacutils.py \
+	   $(RPM_BUILD_ROOT)/usr/lib64/python2.7/site-packages/vac
 	cp VERSION \
 	   $(RPM_BUILD_ROOT)/var/lib/vac
 	cp VERSION vac.conf.5 vacd.8 CHANGES init.pp \

--- a/vac.spec
+++ b/vac.spec
@@ -43,6 +43,7 @@ fi
 /usr/share/man/man8
 /usr/share/doc/vac-%{version}
 /usr/lib64/python2.6/site-packages/vac
+/usr/lib64/python2.7/site-packages/vac
 /var/lib/vac
 /etc/rc.d/init.d/vacd
 /etc/logrotate.d/vacd


### PR DESCRIPTION
Hi Andrew,

The vac package ends up containing a "Requires: python(abi) = 2.6" as seen by:

```
rpm -qip -R vac-0.19+pre1-1.noarch.rpm | grep "python(abi)"
```

This is apparently automatically added by the RPM build tools as described at https://fedoraproject.org/wiki/Packaging:Python#Multiple_Python_Runtimes and bases it on what install paths were used.

I'm not sure if installing it to both will allow either ABI version to be allowed but without changing this requirement somehow, it cannot be installed on Fedora 21 (or probably CentOS 7).
